### PR TITLE
Update Vagrantfile

### DIFF
--- a/starter/Vagrantfile
+++ b/starter/Vagrantfile
@@ -18,18 +18,18 @@ Vagrant.configure("2") do |config|
       config.vm.box_version = "15.4.13.7"
       # Run ifconfig or ip a to find the appropriate interface
       config.vm.network "public_network", :adapter=>3, bridge: "br1"
-      config.vm.network "forwarded_port", guest: 8080, host: 8080
-      config.vm.network "forwarded_port", guest: 9090, host: 9090
-      config.vm.network "forwarded_port", guest: 9100, host: 9100
-      config.vm.network "forwarded_port", guest: 9376, host: 9376
-      config.vm.network "forwarded_port", guest: 3000, host: 3000
+      # config.vm.network "forwarded_port", guest: 8080, host: 8080
+      # config.vm.network "forwarded_port", guest: 9090, host: 9090
+      # config.vm.network "forwarded_port", guest: 9100, host: 9100
+      # config.vm.network "forwarded_port", guest: 9376, host: 9376
+      # config.vm.network "forwarded_port", guest: 3000, host: 3000
 
       # set the static IP for the vagrant box
       node.vm.network "private_network", ip: "192.168.50.101"
       # configure the parameters for VirtualBox provider
       node.vm.provider "virtualbox" do |v|
         v.name = "node#{i}"
-        v.memory = 8192
+        v.memory = 4096
         v.cpus = 2
       end
 


### PR DESCRIPTION
This is my final test with the entire project. I didn't feel that there is a need for port forward configuration for the vagrant file. Because we are using the bridge adapter. When we are working with a bridge adapter we don't need to define port forward configuration in the vagrant file or manually with the virtual box.

Memory size 4096 is enough to complete all the necessary tasks related to the project. It is optional to increase the memory size 8196.